### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.19.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "tslib": "^1.10.0",
     "xml2js": "^0.4.22"
   },


### PR DESCRIPTION
[colors 1.4.2 bug](https://github.com/Marak/colors.js/issues/289) 锁死 colors 版本，解决 cli 使用 1.4.0 以上版本导致初始化不了 iconfont 